### PR TITLE
upgrade to rollup v0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "d3-bundler": "bin/d3-bundler"
   },
   "dependencies": {
-    "rollup": "~0.11.0",
+    "rollup": "~0.15.0",
     "minimist": "1"
   },
   "devDependencies": {


### PR DESCRIPTION
This resolves a bunch of rollup-related issues, particularly rollup/rollup#75. In [my case](https://github.com/18F/college-choice/blob/d3-bundler/js/src/d3-bundle.js), v0.11.0 had issues with splat imports, e.g.

``` js
import * as scale from 'd3-scales';
```
